### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for the whole repo
+* @argyle-systems/link-frontend


### PR DESCRIPTION
:robot: Automated PR to update CODEOWNERS based on repository ownership (admins).

If you believe repository ownership is wrong, make sure only owner team(s) have it listed under `admin_repos` in [terraform](https://github.com/argyle-systems/argyle-terraform/blob/master/infra/organization/github/argyle-systems/teams.tfvars).

If this repository should not be updated, please add it to the `EXCLUDES` list in [github-codeowners-generator.yaml](https://github.com/argyle-systems/argyle-infra-workflows/blob/main/.github/workflows/github-codeowners-generator.yaml).