### PR TITLE
Fix android example app's build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,8 +26,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -42,6 +40,7 @@ android {
     }
 
     defaultConfig {
+        compileSdk 34
         minSdkVersion 26
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -28,8 +28,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'com.argyle'
 
-    compileSdkVersion 34
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -47,6 +45,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.argyle.demo.development.release"
         minSdkVersion 26
+        compileSdk 34
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Apparently error indicated that we need to increase `compileSdk` version. [Tested](https://github.com/argyle-systems/argyle-link-flutter/actions/runs/10244813231)

```
* What went wrong:
Execution failed for task ':argyle_link_flutter:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:/Users/runner/work/argyle-link-flutter/argyle-link-flutter/example/build/argyle_link_flutter/intermediates/merged_res/release/values-v34/values-v34.xml:3: AAPT: error: resource android:color/system_background_dark not found.
```